### PR TITLE
Performance audit on database

### DIFF
--- a/data.sql
+++ b/data.sql
@@ -289,3 +289,7 @@ INSERT INTO visits (animal_id, vet_id, date_of_visit)
 VALUES (10,3,'2020-05-24');
 INSERT INTO visits (animal_id, vet_id, date_of_visit)
 VALUES (10,1,'2021-01-11');
+
+-- Pair programming
+INSERT INTO visits (animal_id, vet_id, date_of_visit) SELECT * FROM (SELECT id FROM animals) animal_ids, (SELECT id FROM vets) vets_ids, generate_series('1980-01-01'::timestamp, '2021-01-01', '4 hours') visit_timestamp;
+INSERT INTO owners (full_name, email) SELECT 'Owner ' || generate_series(1,2500000), 'owner_' || generate_series(1,2500000) || '@mail.com';

--- a/queries.sql
+++ b/queries.sql
@@ -149,3 +149,8 @@ JOIN animals ON visits.animal_id = animals.id
 JOIN species ON animals.species_id = species.id
 WHERE visits.vet_id = 2
 GROUP BY vets.name,animals.species_id,species.name;
+
+-- Pair programming
+EXPLAIN ANALYZE SELECT COUNT(*) FROM visits where animal_id = 4;
+EXPLAIN ANALYZE SELECT * FROM visits where vet_id = 2;
+EXPLAIN ANALYZE SELECT * FROM owners where email = 'owner_18327@mail.com';

--- a/schema.sql
+++ b/schema.sql
@@ -88,3 +88,11 @@ FOREIGN KEY (vet_id) REFERENCES vets (id);
 ALTER TABLE visits
 ADD CONSTRAINT fk_6
 FOREIGN KEY (animal_id) REFERENCES animals (id);
+
+ALTER TABLE owners ADD COLUMN email VARCHAR(120);
+
+CREATE INDEX index_visit_animal_id ON visits(animal_id);
+
+CREATE INDEX index_visit_vet_id ON visits(vet_id);
+
+CREATE INDEX index_owners_email ON owners(email);


### PR DESCRIPTION
# In this Pull request we:
 Added an extra column to the owners table:
```ALTER TABLE owners ADD COLUMN email VARCHAR(120);```

- Ran the following statements to add data to the database 
INSERT INTO visits (animal_id, vet_id, date_of_visit) SELECT * FROM (SELECT id FROM animals) animal_ids, (SELECT id FROM vets) vets_ids, generate_series('1980-01-01'::timestamp, '2021-01-01', '4 hours') visit_timestamp;
insert into owners (full_name, email) select 'Owner ' || generate_series(1,2500000), 'owner_' || generate_series(1,2500000) || '@mail.com'; 

- Checked the initial speed for these queries
```SELECT COUNT(*) FROM visits where animal_id = 4;```
![SELECT COUNT(*) FROM visits where animal_id = 4before](https://github.com/MesakDuduCoder/Vet-clinic/assets/52855706/16efca94-b33d-4624-aa6c-92ccc0a3c56b)
SELECT * FROM visits where vet_id = 2;
![Screenshot from 2023-08-21 21-25-58BEfore](https://github.com/MesakDuduCoder/Vet-clinic/assets/52855706/07850ec9-a18d-4d98-bdf4-34166bf97506)
```SELECT * FROM owners where email = 'owner_18327@mail.com';```
![SELECT * FROM owners where email = 'owner_18327@mail comBefore';](https://github.com/MesakDuduCoder/Vet-clinic/assets/52855706/227a85be-2442-4f99-981f-ce8779413635)
Checked the final speed for these queries
```SELECT COUNT(*) FROM visits where animal_id = 4;```
![SELECT COUNT(*) FROM visits where animal_id = 4After](https://github.com/MesakDuduCoder/Vet-clinic/assets/52855706/a029be91-3247-4f21-88ae-02945756d339)
```SELECT * FROM visits where vet_id = 2;```
![SELECT * FROM visits where vet_id = 2after](https://github.com/MesakDuduCoder/Vet-clinic/assets/52855706/8c15c93a-02e6-48e6-ae40-45ccd03e4607)
```SELECT * FROM owners where email = 'owner_18327@mail.com';```
![SELECT * FROM owners where email = 'owner_18327@mail comafter';](https://github.com/MesakDuduCoder/Vet-clinic/assets/52855706/c49bb188-b9d7-47d9-8be7-b32ff9c68ffd)


